### PR TITLE
Allow more graphics backends

### DIFF
--- a/Sekai.Framework/Graphics/GraphicsContext.cs
+++ b/Sekai.Framework/Graphics/GraphicsContext.cs
@@ -2,11 +2,16 @@
 // Licensed under MIT. See LICENSE for details.
 
 using System;
+using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text;
 using Sekai.Framework.Logging;
+using SharpDX;
+using SharpDX.DXGI;
 using Silk.NET.Windowing;
 using Silk.NET.Windowing.Extensions.Veldrid;
 using Veldrid;
+using Veldrid.OpenGLBinding;
 using Vulkan;
 
 namespace Sekai.Framework.Graphics;
@@ -32,10 +37,16 @@ public class GraphicsContext : FrameworkComponent, IGraphicsContext
                 initializeVulkan();
                 break;
 
-            case GraphicsBackend.Direct3D11:
             case GraphicsBackend.OpenGL:
-            case GraphicsBackend.Metal:
             case GraphicsBackend.OpenGLES:
+                initializeOpenGL();
+                break;
+
+            case GraphicsBackend.Direct3D11:
+                initializeDirect3D11();
+                break;
+
+            case GraphicsBackend.Metal:
             default:
                 throw new NotSupportedException();
         }
@@ -65,9 +76,71 @@ public class GraphicsContext : FrameworkComponent, IGraphicsContext
             _ => $"{properties.driverVersion >> 22}.{(properties.driverVersion >> 12) & 0x3FFU}.{properties.driverVersion & 0xFFFU}"
         };
 
+        uint deviceExtPropCount = 0;
+        VulkanNative.vkEnumerateDeviceExtensionProperties(vkDevice, (byte*)null, ref deviceExtPropCount, null);
+
+        var deviceExtProps = new VkExtensionProperties[(int)deviceExtPropCount];
+        VulkanNative.vkEnumerateDeviceExtensionProperties(vkDevice, (byte*)null, ref deviceExtPropCount, ref deviceExtProps[0]);
+
+        uint instExtPropCount = 0;
+        VulkanNative.vkEnumerateInstanceExtensionProperties((byte*)null, ref instExtPropCount, null);
+
+        var instExtProps = new VkExtensionProperties[(int)instExtPropCount];
+        VulkanNative.vkEnumerateInstanceExtensionProperties((byte*)null, ref instExtPropCount, ref instExtProps[0]);
+
+        string extensions = string.Join(' ', instExtProps.Concat(deviceExtProps).Select(e => Marshal.PtrToStringUTF8((nint)e.extensionName)));
+
         Logger.Log($@"Vulkan Initialized");
-        Logger.Log($@"Vulkan Device: {deviceName}");
-        Logger.Log($@"Vulkan API Version: {apiVersion}");
+        Logger.Log($@"Vulkan Device:         {deviceName}");
+        Logger.Log($@"Vulkan API Version:    {apiVersion}");
         Logger.Log($@"Vulkan Driver Version: {driverVersion}");
+        Logger.Log($@"Vulkan Extensions:     {extensions}");
+    }
+
+    private unsafe void initializeOpenGL()
+    {
+        string vendor = string.Empty;
+        string version = string.Empty;
+        string renderer = string.Empty;
+        string shaderVersion = string.Empty;
+        StringBuilder extensions = new();
+
+        Device.GetOpenGLInfo().ExecuteOnGLThread(() =>
+        {
+            vendor = Marshal.PtrToStringUTF8((nint)OpenGLNative.glGetString(StringName.Vendor)) ?? string.Empty;
+            version = Marshal.PtrToStringUTF8((nint)OpenGLNative.glGetString(StringName.Version)) ?? string.Empty;
+            renderer = Marshal.PtrToStringUTF8((nint)OpenGLNative.glGetString(StringName.Renderer)) ?? string.Empty;
+            shaderVersion = Marshal.PtrToStringUTF8((nint)OpenGLNative.glGetString((StringName)35724)) ?? string.Empty;
+
+            int extensionCount;
+            OpenGLNative.glGetIntegerv(GetPName.NumExtensions, &extensionCount);
+
+            for (uint i = 0; i < extensionCount; i++)
+            {
+                if (i > 0)
+                    extensions.Append(' ');
+
+                extensions.Append(Marshal.PtrToStringUTF8((nint)OpenGLNative.glGetStringi(StringNameIndexed.Extensions, i)));
+            }
+        });
+
+        Logger.Log($@"GL Initialized");
+        Logger.Log($@"GL Version:                 {version}");
+        Logger.Log($@"GL Renderer:                {renderer}");
+        Logger.Log($@"GL Shader Language Version: {shaderVersion}");
+        Logger.Log($@"GL Vendor:                  {vendor}");
+        Logger.Log($@"GL Extensions:              {extensions}");
+    }
+
+    private unsafe void initializeDirect3D11()
+    {
+        var info = Device.GetD3D11Info();
+        var adapter = CppObject.FromPointer<Adapter>(info.Adapter);
+
+        Logger.Log($@"Direct3D 11 Inititalized");
+        Logger.Log($@"Direct3D 11 Adapter:                 {adapter.Description.Description}");
+        Logger.Log($@"Direct3D 11 Dedicated Video Memory:  {adapter.Description.DedicatedVideoMemory / 1024 / 1024} MB");
+        Logger.Log($@"Direct3D 11 Dedicated System Memory: {adapter.Description.DedicatedSystemMemory / 1024 / 1024} MB");
+        Logger.Log($@"Direct3D 11 Shared System Memory:    {adapter.Description.SharedSystemMemory / 1024 / 1024} MB");
     }
 }


### PR DESCRIPTION
Closes #7. A quick one added as #8 refactors `GraphicsContext` to allow this to be possible. Logs are more verbose in addition to that.