### PR TITLE
Provide clearer documentation for engine structure

### DIFF
--- a/analysis/BannedSymbols.txt
+++ b/analysis/BannedSymbols.txt
@@ -2,4 +2,4 @@ M:System.Object.Equals(System.Object,System.Object)~System.Boolean;Don't use obj
 M:System.Object.Equals(System.Object)~System.Boolean;Don't use object.Equals. Use IEquatable<T> or EqualityComparer<T>.Default instead.
 M:System.ValueType.Equals(System.Object)~System.Boolean;Don't use object.Equals(Fallbacks to ValueType). Use IEquatable<T> or EqualityComparer<T>.Default instead.
 T:System.IComparable;Don't use non-generic IComparable. Use generic version instead.
-M:System.Guid.#ctor;Probably meaning to use Guid.NewGuid() instead. If actually wanting empty, use Guid.Empty.
+M:System.Guid.#ctor;You probably meant to use Guid.NewGuid() instead. If you actually want empty, use Guid.Empty.

--- a/source/README.md
+++ b/source/README.md
@@ -1,5 +1,11 @@
 # Sekai Sources
+
+Sekai's source has been split into multiple folders and C# projects (.csproj), each representing a module of the engine. Engine components are split into tiers, with engine being the highest abstraction to the framework, which is dealing with "low-level" calls (with the exception of `extensions`, which are middleware for the engine, and usually reside in the same level as the framework).
+
 ## Folder and Projects Layout
+
+Generally, the folder structure is as follows:
+
 ### engine
 - **Sekai.Engine**
     - Core game engine functionality.
@@ -11,9 +17,9 @@
 - **Sekai.Headless**
     - Provides headless windowing support.
 - **Sekai.SDL**
-    - Provides **SDL 2** windowing and input support.
+    - Provides [**SDL 2**](https://www.libsdl.org/) windowing and input support.
 - **Sekai.Veldrid**
-    - Provides **Veldrid** graphics support.
+    - Provides [**Veldrid**](https://github.com/mellinoe/veldrid) graphics support.
 ### framework
 - **Sekai.Framework**
     - Implements various systems for core functionality such as dependency injection, logging, threading, and storage management.


### PR DESCRIPTION
This elaborates a little more on our engine structure documentation-wise, and provide clearer wording in BannedSymbols.txt