### PR TITLE
Ensure that canceled task exceptions are caught

### DIFF
--- a/source/framework/Sekai.Framework/Threading/ThreadController.cs
+++ b/source/framework/Sekai.Framework/Threading/ThreadController.cs
@@ -195,9 +195,15 @@ public sealed class ThreadController : FrameworkObject
                     renderTasks[i] = Task.Factory.StartNew(render[i].Render, cts.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default);
                 }
 
-                Task.WaitAll(updateFixed, cts.Token);
-                Task.WaitAll(updateTasks, cts.Token);
-                Task.WaitAll(renderTasks, cts.Token);
+                try
+                {
+                    Task.WaitAll(updateFixed, cts.Token);
+                    Task.WaitAll(updateTasks, cts.Token);
+                    Task.WaitAll(renderTasks, cts.Token);
+                }
+                catch (OperationCanceledException)
+                {
+                }
             }
 
             OnTick?.Invoke();


### PR DESCRIPTION
Random exceptions happen on exiting the game during the fixed update step when on multithreaded mode. We just catch the exception and ignore it since we are aware that we're cancelling the task to begin with.