### PR TITLE
Set OpenGL version to 3.3

### DIFF
--- a/source/extensions/Sekai.SDL/SDLGLProvider.cs
+++ b/source/extensions/Sekai.SDL/SDLGLProvider.cs
@@ -18,9 +18,6 @@ internal class SDLGLProvider : FrameworkObject, IOpenGLProvider
     {
         this.view = view;
 
-        if (SDL_GL_SetAttribute(SDL_GLattr.SDL_GL_CONTEXT_PROFILE_MASK, SDL_GLprofile.SDL_GL_CONTEXT_PROFILE_COMPATIBILITY) > 0)
-            throw new InvalidOperationException(SDL_GetError());
-
         Handle = CreateContext();
 
         ClearCurrentContext();

--- a/source/extensions/Sekai.SDL/SDLView.cs
+++ b/source/extensions/Sekai.SDL/SDLView.cs
@@ -47,6 +47,15 @@ internal class SDLView : FrameworkObject, IView, INativeWindowSource, IOpenGLPro
             throw new InvalidOperationException($"Failed to initialize SDL: {SDL_GetError()}");
         }
 
+        if (SDL_GL_SetAttribute(SDL_GLattr.SDL_GL_CONTEXT_PROFILE_MASK, SDL_GLprofile.SDL_GL_CONTEXT_PROFILE_CORE) != 0)
+            throw new InvalidOperationException(SDL_GetError());
+
+        if (SDL_GL_SetAttribute(SDL_GLattr.SDL_GL_CONTEXT_MAJOR_VERSION, 3) != 0)
+            throw new InvalidOperationException(SDL_GetError());
+
+        if (SDL_GL_SetAttribute(SDL_GLattr.SDL_GL_CONTEXT_MINOR_VERSION, 3) != 0)
+            throw new InvalidOperationException(SDL_GetError());
+
         Window = SDL_CreateWindow("Sekai", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 1280, 720, SDL_WindowFlags.SDL_WINDOW_HIDDEN | SDL_WindowFlags.SDL_WINDOW_OPENGL);
         Native = new SDLNativeWindow(this);
 


### PR DESCRIPTION
Forcing OpenGL Core Profile version 3.3 for now. We'll revisit once we want to add ES support later on. This is to have proper support for RenderDoc.