### PR TITLE
Add global logger to cached services

### DIFF
--- a/source/Sekai/GameBuilder.cs
+++ b/source/Sekai/GameBuilder.cs
@@ -13,7 +13,6 @@ using Sekai.Input;
 using Sekai.Logging;
 using Sekai.Processors;
 using Sekai.Rendering;
-using Sekai.Rendering.Batches;
 using Sekai.Storages;
 using Sekai.Windowing;
 
@@ -130,6 +129,7 @@ public sealed class GameBuilder<T>
 
         ServiceLocator.Current.Cache(options);
         ServiceLocator.Current.Cache(factory);
+        ServiceLocator.Current.Cache(factory.GetLogger());
         ServiceLocator.Current.Cache<Time>();
         ServiceLocator.Current.Cache<ProcessorManager>();
         ServiceLocator.Current.Cache<ShaderUniformManager>();


### PR DESCRIPTION
QOL change so we'd never have to get the logger factory just to retrieve the global logger instance.