### PR TITLE
Fix asset loaders throwing `StackOverflowException`

### DIFF
--- a/source/Sekai/Assets/AssetLoader.cs
+++ b/source/Sekai/Assets/AssetLoader.cs
@@ -46,7 +46,8 @@ public sealed class AssetLoader : DependencyObject, IAssetLoaderRegistry
 
         using var stream = storage.Open(path, FileMode.Open, FileAccess.Read);
 
-        Span<byte> data = stackalloc byte[(int)stream.Length];
+        int streamLength = (int)stream.Length;
+        Span<byte> data = streamLength > RuntimeInfo.MaximumStackCapacity ? new byte[streamLength] : stackalloc byte[streamLength];
 
         if (stream.Read(data) <= 0)
             throw new InvalidOperationException(@"Failed to read stream.");

--- a/source/Sekai/Graphics/Textures/Texture.cs
+++ b/source/Sekai/Graphics/Textures/Texture.cs
@@ -188,7 +188,9 @@ public class Texture : GraphicsObject, IAsset
 
         var texture = New2D(image.Width, image.Height, PixelFormat.R8_G8_B8_A8_UNorm);
 
-        Span<byte> data = new byte[image.Width * image.Height * 4];
+        int size = image.Width * image.Height * 4;
+
+        Span<byte> data = size > RuntimeInfo.MaximumStackCapacity ? new byte[size] : stackalloc byte[size];
         image.CopyPixelDataTo(data);
 
         fixed (byte* ptr = data)

--- a/source/Sekai/RuntimeInfo.cs
+++ b/source/Sekai/RuntimeInfo.cs
@@ -49,6 +49,11 @@ public static class RuntimeInfo
     /// </summary>
     public static bool IsApple => OS is Platform.iOS or Platform.macOS;
 
+    /// <summary>
+    /// The maximum stack capacity in bytes.
+    /// </summary>
+    internal static int MaximumStackCapacity => Environment.Is64BitProcess ? 400000 : 100000;
+
     static RuntimeInfo()
     {
         if (OperatingSystem.IsWindows())


### PR DESCRIPTION
Apparently, `stackalloc` has a capacity limit. It depends on the processor architecture of either 32-bit or 64-bit but I've set up arbitrary numbers less than half of what the limit is just to be really sure we're not filling the stack immediately.