### PR TITLE
Window not exiting when `Host.Exit()` is called

### DIFF
--- a/source/Sekai/Host.cs
+++ b/source/Sekai/Host.cs
@@ -253,6 +253,11 @@ public sealed class Host
                 Window.Focus();
                 hasShownWindow = true;
             }
+
+            if (State == HostState.Exited)
+            {
+                break;
+            }
         }
 
         if (gameLoop is not null)


### PR DESCRIPTION
This does close the window but the return code is '-532462766' so figure it out yourself.